### PR TITLE
Run apt autoremove on upgrade

### DIFF
--- a/ubports-qa
+++ b/ubports-qa
@@ -81,6 +81,7 @@ def apt_upgrade():
     LOG.debug("Running 'apt upgrade'.")
     try:
         subprocess.run(["apt", "upgrade"], check=True)
+        subprocess.run(["apt", "autoremove"], check=True)
     except subprocess.CalledProcessError:
         LOG.error("Failed to run 'apt upgrade'. See the output above for details.")
 


### PR DESCRIPTION
This is a good idea if you want to get rid of outdated dependencies, like packages that were removed from the meta-package.