### PR TITLE
Put ubports-qa-installed repositories above xenial repository

### DIFF
--- a/ubports-qa
+++ b/ubports-qa
@@ -131,7 +131,7 @@ def add_pref(branch):
         # removal of repo etc
         pref.write("Package: *\n"
                    "Pin: release o=UBports,a={}\n"
-                   "Pin-Priority: 2000\n".format(branch))
+                   "Pin-Priority: 2001\n".format(branch))
 
 
 def remove_list(branch):


### PR DESCRIPTION
The `xenial` repository is given priority 2000 on the standard release pipeline by [livecd-rootfs' ubports.pref-binary](https://github.com/ubports/livecd-rootfs/blob/xenial/live-build/ubuntu-touch/archives/ubports.pref.binary). By making the priority of our newly installed repository higher, we ensure we install the packages the user probably wanted.