### PR TITLE
mount tmpfs to /var/cache/apt/archives/ to prevent install failure

### DIFF
--- a/ubports-qa
+++ b/ubports-qa
@@ -60,13 +60,12 @@ class WritableRootFS:
         subprocess.run(["umount", "/var/cache/apt/archives"])
         LOG.debug("Attempting to mount rootfs read-only.")
         if not os.path.exists("/userdata/.writable_image"):
-            ensure_root()
             os.sync()
             try:
                 subprocess.run(["mount", "-o", "ro,remount", "/"], check=True)
             except subprocess.CalledProcessError:
-                LOG.error("Failed to remount root filesystem read-only.")
-                LOG.error("Please consider rebooting your device.")
+                LOG.warning("Failed to remount root filesystem read-only.")
+                LOG.warning("Please consider rebooting your device.")
 
 
 def ensure_root():

--- a/ubports-qa
+++ b/ubports-qa
@@ -50,9 +50,14 @@ class WritableRootFS:
         LOG.debug("Attempting to mount rootfs read-write.")
         ensure_root()
         subprocess.run(["mount", "-o", "rw,remount", "/"])
+        LOG.debug("Making sure we have enough free space for archives.")
+        subprocess.run(["mount", "-t", "tmpfs", "tmpfs", "/var/cache/apt/archives"])
 
     @classmethod
     def attempt_unmount(cls):
+        LOG.debug("Unmounting tmpfs")
+        ensure_root()
+        subprocess.run(["umount", "/var/cache/apt/archives"])
         LOG.debug("Attempting to mount rootfs read-only.")
         if not os.path.exists("/userdata/.writable_image"):
             ensure_root()


### PR DESCRIPTION
fix issue with "You don't have enough free space in /var/cache/apt/archives/"