### PR TITLE
Xenial   qa scripts autocompletion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 ubports-qa-scripts (0.2) xenial; urgency=medium
 
+  * Add shell completion
+
+ -- Peter Putz <p.putz@yahoo.de>  Wed, 24 Oct 2018 23:35:01 +0200
+
+ubports-qa-scripts (0.2) xenial; urgency=medium
+
   * Update code style
   * Fix script not mounting root filesystem read-write on several subcommands
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubports-qa-scripts (0.2) xenial; urgency=medium
+ubports-qa-scripts (0.3) xenial; urgency=medium
 
   * Add shell completion
 

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,2 @@
 ubports-qa /usr/bin
+tools/completions/ubports-qa usr/share/bash-completion/completions/ubports-qa

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,2 @@
 ubports-qa /usr/bin
-tools/completions/ubports-qa usr/share/bash-completion/completions/ubports-qa
+tools/completions/ubports-qa usr/share/bash-completion/completions/

--- a/tools/completions/ubports-qa
+++ b/tools/completions/ubports-qa
@@ -1,0 +1,10 @@
+# -*- shell-script -*-
+
+function _ubports-qa()
+{
+    local cur
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    opts="install remove list update"
+    
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur} ) )
+} && complete -F _ubports-qa ubports-qa && complete -F _ubports-qa ./ubports-qa

--- a/tools/completions/ubports-qa
+++ b/tools/completions/ubports-qa
@@ -1,10 +1,62 @@
 # -*- shell-script -*-
 
-function _ubports-qa()
+uqd()
 {
-    local cur
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    opts="install remove list update"
-    
-    COMPREPLY=( $(compgen -W "${opts}" -- ${cur} ) )
-} && complete -F _ubports-qa ubports-qa && complete -F _ubports-qa ./ubports-qa
+    #echo -n $@ >&2
+    true
+}
+
+_installed_qas () 
+{ 
+    # COMPREPLY=($( compgen -W "$( PATH="$PATH:/sbin" lsmod |         awk '{if (NR != 1) print $1}' )" -- "$1" ))
+    # COMPREPLY=($( compgen -W "$( lsmod | awk '{if (NR != 1) print $1}' )" -- "$1" ))
+    COMPREPLY=($( compgen -W "$( echo $( ubports-qa ) )" -- "$1" ))
+}
+
+
+_ubports-qa()
+{
+    local cur cmd opts params list
+    _init_completion -s || return 
+    #cur="${COMP_WORDS[COMP_CWORD]}"
+    cmd="${COMP_WORDS[1]}"
+    #uqd "1(${cmd}:${cur})"
+
+    case "${cmd}" in
+	"install")
+	    uqd I
+	    #params="--help"
+	    opts="asdf jkl aaaa"
+	    ;;
+	"remove")
+	    #uqd "R"
+	    #params="--help"
+	    # opts="rubl roble"
+	    # opts=`echo rubl roble`
+	    # opts=`ubports-qa list | dos2unix | tr "\n" " " | grep -Eve '^ *$' `
+	    # opts=$( lsmod | awk '{if (NR != 1) print $1}' )
+	    _installed_qas "$cur"
+	    return 0
+	    uqd "R(${opts})"
+	    ;;
+	"list")
+	    uqd L
+	    #params="--help"
+	    opts=""
+	    ;;
+	"update")
+	    uqd U
+	    #params="--help"
+	    opts=""
+	    ;;
+	*)
+	    uqd N
+	    #params="--help"
+	    opts="install remove list update"
+	    ;;
+    esac
+    #uqd "2(${params})"
+    uqd "3(${opts})"
+    COMPREPLY=( $(compgen -W "${params} ${opts}" -- ${cur} ) )
+
+} && complete -F _ubports-qa ubports-qa

--- a/tools/completions/ubports-qa
+++ b/tools/completions/ubports-qa
@@ -26,7 +26,7 @@ _ubports-qa()
 	"install")
 	    uqd I
 	    #params="--help"
-	    opts="asdf jkl aaaa"
+	    opts="asdf jkl aaaa x"
 	    ;;
 	"remove")
 	    #uqd "R"

--- a/ubports-qa
+++ b/ubports-qa
@@ -200,12 +200,12 @@ parser_install = subparsers.add_parser(
 parser_install.add_argument(
     "repo",
     type=str,
-    help="Name of a PPA on repo.ubports.com. Alternatively, if the 'pr' argument is provided, the name of a git repository can be specified to automatically add the PPA from a pull-request.",
+    help="Name of a PPA on repo.ubports.com. Note that for certain branches on github, PPAs are automatically created. For example branch names that start with \"xenial_-_\" have such automatic PPAs. Example: 'ubports-qa install xenial_-_sessionrestore'. Alternatively, see below how 'repo' is interpreted if the 'pr' argument is used.",
 )
 parser_install.add_argument(
     "pr",
     type=int,
-    help="Numeric ID of a pull-request on the git repository specified in the 'repo' argument. If 'repo' is supposed to be the name of a ppa, the 'pr' argument should not be specified.",
+    help="Numeric ID of a pull-request. When this 'pr' parameter is used, then the 'repo' parameter is interpreted as the name of a github repository. Example: 'ubports-qa calendar-app 123'",
     nargs="?",
     default=-1,
 )


### PR DESCRIPTION
This branch must be removed to allow Jenkins to rescan the repository. If it is also filed as a PR, it will be possible to restore the branch from the PR after deletion.