### PR TITLE
Choose the correct base for repo

### DIFF
--- a/ubports-qa
+++ b/ubports-qa
@@ -118,13 +118,20 @@ def list_lists():
     ]
 
 
+def repo_base(repo: str):
+    if repo.startswith("xenial"):
+        return "http://repo.ubports.com/"
+    else: # This includes base-less PRs
+        return "http://repo2.ubports.com/"
+
 def add_list(branch):
     if list_exists(branch):
         return
-    if requests.get("http://repo.ubports.com/dists/" + branch).status_code != 200:
+    base = repo_base(branch)
+    if requests.head("{}dists/{}/".format(base, branch) ).status_code != 200:
         die("PPA not found")
     with open(get_list_file(branch), "w+") as repo_list:
-        repo_list.write("deb http://repo.ubports.com/ {} main".format(branch))
+        repo_list.write("deb {} {} main".format(base, branch))
 
 
 def add_pref(branch):


### PR DESCRIPTION
Base-less PRs are now (accidentally) published on repo2 only. So let's
head that direction. It'll also choose the correct base for focal repos.