### PR TITLE
d/changelog: bump version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+ubports-qa-scripts (0.4) UNRELEASED; urgency=medium
+
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Wed, 07 Apr 2021 16:29:55 +0700
+
 ubports-qa-scripts (0.3) xenial; urgency=medium
 
   * Log using a logger rather than print statements


### PR DESCRIPTION
Due to a change in CI, the new build's version no longer trumps the ones
that's already in the repo. Thus, this bump is needed.